### PR TITLE
Add BG3 connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # FlexPluginBG3
 
 FlexPluginBG3 allows Baldur's Gate 3 information to be shown on your FlexBar device.
+
+## Connection
+
+This plugin tests connectivity with the Baldur's Gate 3 Script Extender. When
+the game is started with the script extender and Lua debugger enabled, the
+extender opens a TCP port (default `9998`). The plugin attempts to connect to
+`127.0.0.1:9998` on startup and logs the result.
+
+Ensure you have the Script Extender installed and the `EnableLuaDebugger` option
+set to `true` in `ScriptExtenderSettings.json` before launching the game.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,3 +94,27 @@ plugin.on('plugin.data', (payload) => {
 
 // Connect to flexdesigner and start the plugin
 plugin.start()
+
+// ---------------------------------------------------------------------------
+// Baldur's Gate 3 connection test
+// ---------------------------------------------------------------------------
+const net = require('node:net')
+
+/**
+ * Attempt to connect to the BG3 Lua debugger. The Script Extender exposes a TCP
+ * socket (default 9998) when the EnableLuaDebugger option is enabled.
+ */
+function connectToBG3(host = '127.0.0.1', port = 9998) {
+  logger.info(`Attempting BG3 connection to ${host}:${port}`)
+  const client = new net.Socket()
+  client.connect(port, host, () => {
+    logger.info('Connected to Baldur\'s Gate 3')
+    client.end()
+  })
+  client.on('error', (err) => {
+    logger.error('Failed to connect to BG3:', err.message)
+  })
+}
+
+// Kick off connection attempt
+connectToBG3()


### PR DESCRIPTION
## Summary
- attempt to connect to the BG3 Script Extender debugger when the plugin starts
- document how the plugin connects to BG3

## Testing
- `npm run plugin:validate` *(fails: flexcli not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850cea54ad083258ede4026944dc352