### PR TITLE
Add Node 20 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ extender opens a TCP port (default `9998`). The plugin attempts to connect to
 
 Ensure you have the Script Extender installed and the `EnableLuaDebugger` option
 set to `true` in `ScriptExtenderSettings.json` before launching the game.
+
+## Testing
+
+This project requires **Node.js 20** or newer. Make sure Node 20 is installed
+before running any npm scripts or tests.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "plugin:install": "flexcli plugin install --path ./com.lucas_godfrey.flexpluginbg.flexplugin --force"
   },
   "type": "commonjs",
+  "engines": {
+    "node": "^20"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.2.2",


### PR DESCRIPTION
## Summary
- specify Node.js 20 compatibility in `package.json`
- mention Node 20 requirement in README testing section

## Testing
- `npm run build`
- `npm run plugin:validate` *(fails: flexcli not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d311a6548325b173331edefa9b11