### PR TITLE
Remove Script Extender requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ dependencies.
 
 ## Connection
 
-This plugin tests connectivity with the Baldur's Gate 3 Script Extender. When
-the game is started with the script extender and Lua debugger enabled, the
-extender opens a TCP port (default `9998`). The plugin attempts to connect to
-`127.0.0.1:9998` on startup and logs the result.
+This plugin monitors the Baldur's Gate 3 `Player.log` file to detect game
+activity. No Script Extender is required. On macOS the log is located at:
 
-Ensure you have the Script Extender installed and the `EnableLuaDebugger` option
-set to `true` in `ScriptExtenderSettings.json` before launching the game.
+```
+~/Library/Application Support/Larian Studios/Baldur's Gate 3/Player.log
+```
+
+When the log file is updated, new lines are printed to the plugin console.
 
 ## Testing
 
@@ -42,6 +43,6 @@ before running any npm scripts or tests.
    npm run plugin:debug
    ```
 
-4. Launch Baldur's Gate 3 with the Script Extender and `EnableLuaDebugger` enabled.
+4. Launch Baldur's Gate 3.
 
-5. Confirm that the plugin connects by checking the console logs.
+5. Confirm that the plugin reports log lines in the console.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -131,7 +131,7 @@ function watchBG3Logs(logPath = BG3_LOG_PATH) {
       if (stats.size > lastSize) {
         const stream = fs.createReadStream(logPath, {
           start: lastSize,
-          end: stats.size
+          end: stats.size - 1
         })
         stream.on('data', (chunk) => {
           const lines = chunk.toString().split(/\r?\n/).filter(Boolean)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -128,6 +128,10 @@ function watchBG3Logs(logPath = BG3_LOG_PATH) {
         }
         return
       }
+      if (stats.size < lastSize) {
+        logger.info('Log file truncated or rotated. Resetting lastSize to 0.')
+        lastSize = 0
+      }
       if (stats.size > lastSize) {
         const stream = fs.createReadStream(logPath, {
           start: lastSize,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -96,29 +96,60 @@ plugin.on('plugin.data', (payload) => {
 plugin.start()
 
 // ---------------------------------------------------------------------------
-// Baldur's Gate 3 connection test
+// Baldur's Gate 3 log file monitor (macOS compatible)
 // ---------------------------------------------------------------------------
-const net = require('node:net')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
-// Default connection settings for Baldur's Gate 3 Lua debugger
-const DEFAULT_BG3_HOST = '127.0.0.1'
-const DEFAULT_BG3_PORT = 9998
+// Default macOS log path for Baldur's Gate 3
+const BG3_LOG_PATH = path.join(
+  os.homedir(),
+  'Library',
+  'Application Support',
+  'Larian Studios',
+  "Baldur's Gate 3",
+  'Player.log'
+)
 
 /**
- * Attempt to connect to the BG3 Lua debugger. The Script Extender exposes a TCP
- * socket (default 9998) when the EnableLuaDebugger option is enabled.
+ * Monitor the Player.log file for new entries. This does not require the
+ * Script Extender and works with the standard macOS version of BG3.
  */
-function connectToBG3(host = DEFAULT_BG3_HOST, port = DEFAULT_BG3_PORT) {
-  logger.info(`Attempting BG3 connection to ${host}:${port}`)
-  const client = new net.Socket()
-  client.connect(port, host, () => {
-    logger.info('Connected to Baldur\'s Gate 3')
-    client.end()
-  })
-  client.on('error', (err) => {
-    logger.error('Failed to connect to BG3:', err.message)
-  })
+function watchBG3Logs(logPath = BG3_LOG_PATH) {
+  logger.info(`Watching BG3 log: ${logPath}`)
+  let lastSize = 0
+
+  const readNewLines = () => {
+    fs.stat(logPath, (err, stats) => {
+      if (err) {
+        if (err.code !== 'ENOENT') {
+          logger.error('Error reading log file:', err.message)
+        }
+        return
+      }
+      if (stats.size > lastSize) {
+        const stream = fs.createReadStream(logPath, {
+          start: lastSize,
+          end: stats.size
+        })
+        stream.on('data', (chunk) => {
+          const lines = chunk.toString().split(/\r?\n/).filter(Boolean)
+          for (const line of lines) {
+            logger.info(`[BG3] ${line}`)
+          }
+        })
+        stream.on('end', () => {
+          lastSize = stats.size
+        })
+      }
+    })
+  }
+
+  fs.watchFile(logPath, { interval: 1000 }, readNewLines)
+  // Initial read if file already exists
+  readNewLines()
 }
 
-// Kick off connection attempt
-connectToBG3()
+// Start watching the log file
+watchBG3Logs()


### PR DESCRIPTION
## Summary
- monitor BG3 `Player.log` instead of TCP socket
- update README to describe log monitoring

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ded7a16483258ede5186b911aaf2