### PR TITLE
Add simple macOS installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ FlexPluginBG3 allows Baldur's Gate 3 information to be shown on your FlexBar dev
 current test build targets **macOS** and does not include any Windows specific
 dependencies.
 
+## Easy Install (macOS)
+
+1. Install Node 20 or newer from [nodejs.org](https://nodejs.org).
+2. Download or clone this repository.
+3. Open Terminal and run `./install.sh` inside the project folder.
+
+The installer will build and install the plugin. Launch FlexBar when it finishes.
+
+
 ## Connection
 
 This plugin monitors the Baldur's Gate 3 `Player.log` file to detect game

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+echo "FlexPluginBG3 Installer"
+
+# Check Node.js
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js 20 or newer is required. Please install it from https://nodejs.org/ and rerun this installer." >&2
+  exit 1
+fi
+
+# Check npm
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required. Please install Node.js 20 or newer." >&2
+  exit 1
+fi
+
+# Install flexcli if missing
+if ! command -v flexcli >/dev/null 2>&1; then
+  echo "flexcli not found. Installing globally..."
+  npm install -g @eniac/flexcli
+fi
+
+echo "Installing dependencies..."
+npm install
+
+echo "Building plugin..."
+npm run build
+
+echo "Packaging plugin..."
+npm run plugin:pack
+
+echo "Installing plugin..."
+npm run plugin:install
+
+echo "Done! Launch your FlexBar software to try the plugin."


### PR DESCRIPTION
## Summary
- document easy install steps for macOS users
- add `install.sh` helper script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850e12b0e2083259eedb1bf73998cd3